### PR TITLE
Ensure dialog is cancelable by clicking outside of the dialog

### DIFF
--- a/Picker.js
+++ b/Picker.js
@@ -28,69 +28,87 @@ class Picker extends Component {
     this.state = {};
   }
 
+  onPressPicker(values, labels) {
+    NativeModules.FixedAndroidPicker.showPickerDialog(labels).then((index) => {
+      this.setState({
+        selectedValue: values[index],
+      });
+      this.props.onValueChange(values[index], index);
+    }).catch((error) => {
+      //dialog closed
+    });
+  }
+
   render() {
-    const theme = this.props.theme;
-
-    var dropDownImageSource;
-    if (this.props.dropDownImageSource) {
-      dropDownImageSource = this.props.dropDownImageSource;
-    } else if (theme == THEMES.LIGHT) {
-      dropDownImageSource = dropDownImageBlack;
-    } else {
-      dropDownImageSource = dropDownImageWhite;
-    }
-
     const items = this.props.items;
     const labels = this.getLabels(items);
     const values = this.getValues(items);
 
+    const renderDropDown = this.props.renderDropDown ?
+      this.props.renderDropDown : this.renderDropDown;
+
     return (
       <View
-        style={theme == THEMES.LIGHT ? styles.backgroundWhite : styles.backgroundBlack}>
+        style={this.getTheme() == THEMES.LIGHT ? styles.backgroundWhite : styles.backgroundBlack}>
         <TouchableNativeFeedback
-          underlayColor={theme == THEMES.LIGHT ? '#FFFFFF' : '#000000'}
+          underlayColor={this.getTheme() == THEMES.LIGHT ? '#FFFFFF' : '#000000'}
           style={styles.padding5}
           onPress={() => {
-            NativeModules.FixedAndroidPicker.showPickerDialog(labels).then((index) => {
-              this.setState({
-                selectedValue: values[index],
-              });
-              this.props.onValueChange(values[index], index);
-            }).catch((error) => {
-              //dialog closed
-            });
+            this.onPressPicker(values, labels);
           }}>
 
-          <View
-            style={[
-              styles.flexDirectionRow,
-              styles.alignItemsCenter,
-            ]}>
-
-            <Text
-              style={[
-                theme == THEMES.LIGHT ? styles.fontBlack : styles.fontWhite,
-                this.props.styles.label,
-              ]}>
-              {
-                labels[values.indexOf(this.state.selectedValue ? this.state.selectedValue : this.props.selectedValue)]
-              }
-            </Text>
-
-            <Image
-              source={dropDownImageSource}
-              style={[
-                styles.dropDownImage,
-                styles.marginLeft5,
-                this.props.styles.icon,
-              ]}
-              />
-
-          </View>
+            {
+              renderDropDown(labels, values)
+            }
 
         </TouchableNativeFeedback>
       </View>
     );
+  }
+
+  getTheme() {
+    return this.props.theme;
+  }
+
+  renderDropDown(labels, values) {
+    return (
+      <View
+        style={[
+          styles.flexDirectionRow,
+          styles.alignItemsCenter,
+        ]}>
+          <Text
+            style={[
+              this.props.theme == THEMES.LIGHT ? styles.fontBlack : styles.fontWhite,
+              this.props.styles.label,
+            ]}>
+            {
+              labels[values.indexOf(this.state.selectedValue ? this.state.selectedValue : this.props.selectedValue)]
+            }
+        </Text>
+
+        <Image
+          source={this.getDropDownSource()}
+          style={[
+            styles.dropDownImage,
+            styles.marginLeft5,
+            this.props.styles.icon,
+          ]}
+          />
+      </View>
+    );
+  }
+
+  getDropDownSource() {
+    let dropDownImageSource;
+    if (this.props.dropDownImageSource) {
+      dropDownImageSource = this.props.dropDownImageSource;
+    } else if (this.getTheme() == THEMES.LIGHT) {
+      dropDownImageSource = dropDownImageBlack;
+    } else {
+      dropDownImageSource = dropDownImageWhite;
+    }
+    return dropDownImageSource;
   }
 
   getLabels(items) {
@@ -124,6 +142,7 @@ Picker.propTypes = {
     icon: PropTypes.number,
     label: PropTypes.number,
   }),
+  renderDropDown: PropTypes.func,
 };
 
 Picker.defaultProps = {

--- a/README.md
+++ b/README.md
@@ -59,12 +59,23 @@ class SomeComponent extends Component {
 
 ## Custom styling
 
-This picker is made of a few components which makes it difficult to support custom styling since:
-  - you would need to know what each component does
-  - you would likely need to pass style props for each of those components
-  - the native Android dialog shown with the picker's options needs to be themed natively
+Custom styling is difficult because this library uses a mixture of React Native views and Android native dialogs
 
-We have provided support for passing a styles prop which can change how the label and icon for the picker look:
+The simplest custom styling can be applied by using one of our predefined themes (Themes.DARK or Themes.LIGHT):
+```javascript
+import Picker, {
+  Themes,
+} from 'react-native-fixed-android-picker';
+
+...
+
+<Picker
+  items={this.fruitItems}
+  ...
+  theme={Themes.DARK} />
+```
+
+Alternatively, we have provided support for passing a styles prop which can change how the label and icon for the dropdown look:
 
 ```javascript
 <Picker
@@ -82,21 +93,26 @@ We have provided support for passing a styles prop which can change how the labe
   }} />
 ```
 
-We have also provided support for two predefined themes (Themes.DARK or Themes.LIGHT):
+Or you can even render your own custom view for the dropdown:
 ```javascript
-import Picker, {
-  Themes,
-} from 'react-native-fixed-android-picker';
+const renderCustomView = (labels, values) => {
+  //TODO: do something with the labels
+  return (
+    <View />
+  );
+};
 
 ...
 
-<Picker
-  items={this.fruitItems}
-  ...
-  theme={Themes.DARK} />
+const picker = (
+  <Picker
+    items={this.fruitItems}
+    ...
+    renderDropDown={renderCustomView} />
+)
 ```
 
-If neither of these options work for you, feel free to take a fork of this library and change it how you wish.
+If none of these options work for you, feel free to take a fork of this library and change it how you wish.
 
 ## License
 

--- a/android/src/main/java/me/tombailey/fixedandroidpicker/FixedAndroidPickerModule.java
+++ b/android/src/main/java/me/tombailey/fixedandroidpicker/FixedAndroidPickerModule.java
@@ -28,7 +28,7 @@ public class FixedAndroidPickerModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void showPickerDialog(ReadableArray labelsReadableArray, final Promise promise) {
         final String[] labels = getLabels(labelsReadableArray);
-        new AlertDialog.Builder(getCurrentActivity())
+        AlertDialog alertDialog = AlertDialog.Builder(getCurrentActivity())
             .setItems(labels, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int itemIndex) {
@@ -43,6 +43,7 @@ public class FixedAndroidPickerModule extends ReactContextBaseJavaModule {
                 }
             })
             .show();
+        alertDialog.setCanceledOnTouchOutside(true);
     }
 
     private String[] getLabels(ReadableArray labelsReadableArray) {

--- a/android/src/main/java/me/tombailey/fixedandroidpicker/FixedAndroidPickerModule.java
+++ b/android/src/main/java/me/tombailey/fixedandroidpicker/FixedAndroidPickerModule.java
@@ -28,7 +28,7 @@ public class FixedAndroidPickerModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void showPickerDialog(ReadableArray labelsReadableArray, final Promise promise) {
         final String[] labels = getLabels(labelsReadableArray);
-        AlertDialog alertDialog = AlertDialog.Builder(getCurrentActivity())
+        AlertDialog alertDialog = new AlertDialog.Builder(getCurrentActivity())
             .setItems(labels, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int itemIndex) {


### PR DESCRIPTION
On some Android phones (mainly Samsung, running TouchWiz), the dialog was not cancelable by clicking on the background. The small changes I've made ensure it's possible to do this.